### PR TITLE
Support testing UniValue with JSON Parsing Test Suite

### DIFF
--- a/src/univalue/Makefile.am
+++ b/src/univalue/Makefile.am
@@ -20,7 +20,7 @@ libunivalue_la_LDFLAGS = \
 	-no-undefined
 libunivalue_la_CXXFLAGS = -I$(top_srcdir)/include
 
-TESTS = test/unitester
+TESTS = test/unitester test/test_json
 
 GENBIN = gen/gen$(BUILD_EXEEXT)
 GEN_SRCS = gen/gen.cpp
@@ -41,6 +41,11 @@ test_unitester_SOURCES = test/unitester.cpp
 test_unitester_LDADD = libunivalue.la
 test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(TEST_DATA_DIR)\"
 test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
+
+test_test_json_SOURCES = test/test_json.cpp
+test_test_json_LDADD = libunivalue.la
+test_test_json_CXXFLAGS = -I$(top_srcdir)/include
+test_test_json_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
 TEST_FILES = \
 	$(TEST_DATA_DIR)/fail10.json \

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -124,9 +124,10 @@ public:
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
 
+    bool read(const char *raw, size_t len);
     bool read(const char *raw);
     bool read(const std::string& rawStr) {
-        return read(rawStr.c_str());
+        return read(rawStr.data(), rawStr.size());
     }
 
 private:
@@ -240,7 +241,7 @@ enum jtokentype {
 };
 
 extern enum jtokentype getJsonToken(std::string& tokenVal,
-                                    unsigned int& consumed, const char *raw);
+                                    unsigned int& consumed, const char *raw, const char *end);
 extern const char *uvTypeName(UniValue::VType t);
 
 static inline bool jsonTokenIsValue(enum jtokentype jtt)

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -104,7 +104,7 @@ static bool validNumStr(const string& s)
 {
     string tokenVal;
     unsigned int consumed;
-    enum jtokentype tt = getJsonToken(tokenVal, consumed, s.c_str());
+    enum jtokentype tt = getJsonToken(tokenVal, consumed, s.data(), s.data() + s.size());
     return (tt == JTOK_NUMBER);
 }
 

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -43,20 +43,20 @@ static const char *hatoui(const char *first, const char *last,
 }
 
 enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
-                            const char *raw)
+                            const char *raw, const char *end)
 {
     tokenVal.clear();
     consumed = 0;
 
     const char *rawStart = raw;
 
-    while ((*raw) && (json_isspace(*raw)))             // skip whitespace
+    while (raw < end && (json_isspace(*raw)))          // skip whitespace
         raw++;
 
-    switch (*raw) {
-
-    case 0:
+    if (raw >= end)
         return JTOK_NONE;
+
+    switch (*raw) {
 
     case '{':
         raw++;
@@ -127,40 +127,40 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
         numStr += *raw;                       // copy first char
         raw++;
 
-        if ((*first == '-') && (!json_isdigit(*raw)))
+        if ((*first == '-') && (raw < end) && (!json_isdigit(*raw)))
             return JTOK_ERR;
 
-        while ((*raw) && json_isdigit(*raw)) {     // copy digits
+        while (raw < end && json_isdigit(*raw)) {  // copy digits
             numStr += *raw;
             raw++;
         }
 
         // part 2: frac
-        if (*raw == '.') {
+        if (raw < end && *raw == '.') {
             numStr += *raw;                   // copy .
             raw++;
 
-            if (!json_isdigit(*raw))
+            if (raw >= end || !json_isdigit(*raw))
                 return JTOK_ERR;
-            while ((*raw) && json_isdigit(*raw)) { // copy digits
+            while (raw < end && json_isdigit(*raw)) { // copy digits
                 numStr += *raw;
                 raw++;
             }
         }
 
         // part 3: exp
-        if (*raw == 'e' || *raw == 'E') {
+        if (raw < end && (*raw == 'e' || *raw == 'E')) {
             numStr += *raw;                   // copy E
             raw++;
 
-            if (*raw == '-' || *raw == '+') { // copy +/-
+            if (raw < end && (*raw == '-' || *raw == '+')) { // copy +/-
                 numStr += *raw;
                 raw++;
             }
 
-            if (!json_isdigit(*raw))
+            if (raw >= end || !json_isdigit(*raw))
                 return JTOK_ERR;
-            while ((*raw) && json_isdigit(*raw)) { // copy digits
+            while (raw < end && json_isdigit(*raw)) { // copy digits
                 numStr += *raw;
                 raw++;
             }
@@ -178,11 +178,14 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
         JSONUTF8StringFilter writer(valStr);
 
         while (true) {
-            if ((unsigned char)*raw < 0x20)
+            if (raw >= end || (unsigned char)*raw < 0x20)
                 return JTOK_ERR;
 
             else if (*raw == '\\') {
                 raw++;                        // skip backslash
+
+                if (raw >= end)
+                    return JTOK_ERR;
 
                 switch (*raw) {
                 case '"':  writer.push_back('\"'); break;
@@ -196,7 +199,8 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
 
                 case 'u': {
                     unsigned int codepoint;
-                    if (hatoui(raw + 1, raw + 1 + 4, codepoint) !=
+                    if (raw + 1 + 4 >= end ||
+                        hatoui(raw + 1, raw + 1 + 4, codepoint) !=
                                raw + 1 + 4)
                         return JTOK_ERR;
                     writer.push_back_u(codepoint);
@@ -246,7 +250,7 @@ enum expect_bits {
 #define setExpect(bit) (expectMask |= EXP_##bit)
 #define clearExpect(bit) (expectMask &= ~EXP_##bit)
 
-bool UniValue::read(const char *raw)
+bool UniValue::read(const char *raw, size_t size)
 {
     clear();
 
@@ -257,10 +261,11 @@ bool UniValue::read(const char *raw)
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;
+    const char* end = raw + size;
     do {
         last_tok = tok;
 
-        tok = getJsonToken(tokenVal, consumed, raw);
+        tok = getJsonToken(tokenVal, consumed, raw, end);
         if (tok == JTOK_NONE || tok == JTOK_ERR)
             return false;
         raw += consumed;
@@ -437,10 +442,13 @@ bool UniValue::read(const char *raw)
     } while (!stack.empty ());
 
     /* Check that nothing follows the initial construct (parsed above).  */
-    tok = getJsonToken(tokenVal, consumed, raw);
+    tok = getJsonToken(tokenVal, consumed, raw, end);
     if (tok != JTOK_NONE)
         return false;
 
     return true;
 }
 
+bool UniValue::read(const char *raw) {
+    return read(raw, strlen(raw));
+}

--- a/src/univalue/lib/univalue_utffilter.h
+++ b/src/univalue/lib/univalue_utffilter.h
@@ -27,6 +27,8 @@ public:
                 is_valid = false;
             else if (ch < 0xe0) { // Start of 2-byte sequence
                 codepoint = (ch & 0x1f) << 6;
+                if (codepoint <= 0x7f)
+                    is_valid = false; // Unnecessary 2-byte sequence, invalid
                 state = 6;
             } else if (ch < 0xf0) { // Start of 3-byte sequence
                 codepoint = (ch & 0x0f) << 12;

--- a/src/univalue/test/test_json.cpp
+++ b/src/univalue/test/test_json.cpp
@@ -1,0 +1,49 @@
+// Test program that can be called by JSON test suite at
+// https://github.com/nst/JSONTestSuite.
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include "univalue.h"
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#endif
+
+using namespace std;
+
+string ReadFile(const char* filename) {
+    ifstream file(filename, ios::binary);
+    if (!file) throw runtime_error("ifstream open failed");
+    file.seekg(0, ios::end);
+    ifstream::pos_type length = file.tellg();
+    string str;
+    str.resize(length);
+    file.seekg(0, ios::beg);
+    file.read(&str[0], length);
+    return str;
+}
+
+int main (int argc, char *argv[])
+{
+    if (argc != 2) {
+        cerr << "Usage: test_json filename" << endl;
+        return 2;
+    }
+
+    try {
+      UniValue val;
+      string str = ReadFile(argv[1]);
+      if (val.read(str)) {
+        cout << val.write(1 /* prettyIndent */, 4 /* indentLevel */) << endl;
+        return 0;
+      } else {
+        cerr << "JSON Parse Error." << endl;
+        return 1;
+      }
+
+    } catch (const std::runtime_error& e) {
+        cerr << "Error" << e.what() << endl;
+        return 3;
+    }
+}


### PR DESCRIPTION
Changes to support using UniValue with https://github.com/nst/JSONTestSuite, as suggested in https://github.com/bitcoin/bitcoin/issues/9028.

The first commit adds a test_json driver program that's compatible with https://github.com/nst/JSONTestSuite/blob/master/run_tests.py, so the tests can be run automatically.

The second commit extends `UniValue::Read()` to support reading standalone number/string/bool/null values that aren't arrays or objects. It fixes the following tests:

```
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_negative_real.json
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_string.json
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_false.json
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_null.json
bitcoin SHOULD_HAVE_PASSED  y_string_space.json
bitcoin SHOULD_HAVE_PASSED  y_structure_string_empty.json
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_int.json
bitcoin SHOULD_HAVE_PASSED  y_structure_lonely_true.json
```

The third commit extends `UniValue::Read` to take char pointer and length arguments instead of a c string, so '\0' characters aren't no longer treated specially. It fixes the following test:

```
bitcoin SHOULD_HAVE_FAILED  n_multidigit_number_then_00.json
```

The fourth commit makes `JSONUTF8StringFilter` detect non-minimal utf8 sequences as invalid. It fixes the following test:

```
bitcoin SHOULD_HAVE_FAILED  n_multidigit_number_then_00.json
```

After these commits, 2 tests are still broken, but fixing them would require adding support for utf16 decoding, which would probably be overkill.

```
bitcoin	SHOULD_HAVE_PASSED	y_string_utf16LE_no_BOM.json
bitcoin	SHOULD_HAVE_PASSED	y_string_utf16BE_no_BOM.json
```